### PR TITLE
Allow specifying custom ports

### DIFF
--- a/Sources/SwiftHole/Service/Environment.swift
+++ b/Sources/SwiftHole/Service/Environment.swift
@@ -9,5 +9,6 @@ import Foundation
 
 internal struct Environment {
     var host: String
+    var port: Int?
     var apiToken: String?
 }

--- a/Sources/SwiftHole/Service/Router.swift
+++ b/Sources/SwiftHole/Service/Router.swift
@@ -42,6 +42,16 @@ internal enum Router {
             return "/admin/api.php"
         }
     }
+
+    var port: Int? {
+        switch self {
+        case .getSummary(let environment),
+             .getLogs (let environment),
+             .disable(let environment, _),
+             .enable (let environment):
+            return environment.port        
+        }
+    }
     
     var method: String {
         switch self {

--- a/Sources/SwiftHole/Service/Service.swift
+++ b/Sources/SwiftHole/Service/Service.swift
@@ -55,6 +55,7 @@ internal struct Service {
         components.scheme = router.scheme
         components.host = router.host
         components.path = router.path
+        components.port = router.port
         components.queryItems = router.parameters
         guard let url = components.url else {
             return nil

--- a/Sources/SwiftHole/SwiftHole.swift
+++ b/Sources/SwiftHole/SwiftHole.swift
@@ -11,8 +11,8 @@ public struct SwiftHole {
     
     // MARK: Public Methods
 
-    public init(host: String, apiToken: String? = nil) {
-        environment = Environment(host: host, apiToken: apiToken)
+    public init(host: String, port: Int? = nil, apiToken: String? = nil) {
+        environment = Environment(host: host, port: port, apiToken: apiToken)
     }
     
     public func fetchSummary(completion: @escaping (Result<Summary, SwiftHoleError>) -> ()) {


### PR DESCRIPTION
My Pi-Hole runs in Docker on a Synology NAS, so it uses a non-standard port. This change adds an optional configurable `port` parameter which will be used when constructing requests.