### PR TITLE
Fix breaking change to pihole AdminLTE api response

### DIFF
--- a/Sources/SwiftHole/Service/Router.swift
+++ b/Sources/SwiftHole/Service/Router.swift
@@ -71,8 +71,9 @@ internal enum Router {
     
     var parameters: [URLQueryItem] {
         switch self {
-        case .getSummary:
-            return []
+        case .getSummary (let environment):
+            return [URLQueryItem(name: "summaryRaw", value: ""),
+                    URLQueryItem(name: "auth", value: environment.apiToken ?? "")]
             
         case .getLogs (let environment):
             return [URLQueryItem(name: "getAllQueries", value: "100"),


### PR DESCRIPTION
### Summary of Changes in this PR

* Add auth token to summary API endpoint request.
* Default /api.php endpoint no longer returns raw values, switch to using summaryRaw query param.


### Background

The latest pi-hole/AdminLTE [version 5.18](https://github.com/pi-hole/AdminLTE/releases/tag/v5.18) release yesterday introduced a change to how this project, and related [Bunn/PiStats](https://github.com/Bunn/PiStats) project, interprets the API response.

Prior to pi-hole/AdminLTE v5.18 you could invoke the API endpoint `/api.php` without any authentication, and by default the API would return summary stats for the Pi-Hole.  After v5.18 was released, the `auth` token was required as a parameter similar to other endpoints.

Once the `auth` token was added to the request `/api.php?auth=<TOKEN>`, the API would return the `summary` response which contains formatted strings for most fields.  This breaks SwiftHole's decoding of the response.

See an explanation at:  pi-hole/AdminLTE#2468

And an announcement:  https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required/


### Testing

Tested with the latest version of PiStats, which depends on v1.4 of this project.  The pi-hole was running:

* Pi-Hole: v5.14.2
* AdminLTE: v5.18
* FTL: v5.20

This change fixes the auth, and invokes the `summaryRaw` API endpoint to ensure SwiftHole can decode the JSON response properly.

⚠️ I noticed that this project has since been updated to v1.5.1, and there are some breaking changes which prevent PiStats from compiling.  

**I would love if this fix could be applied to the App Store version of PiStats for macOS and iOS, as I have really enjoyed using it over the years!**